### PR TITLE
Add authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1020,6 +1041,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1255,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 name = "scheduling-backend"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "axum",
  "chrono",
  "dotenv",
@@ -1476,6 +1509,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1557,6 +1591,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -1596,6 +1631,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -1621,6 +1657,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -1922,6 +1959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-uuid = { version = "1.8.0", features = ["v4"] }
+uuid = { version = "1.8.0", features = ["v4", "serde"] }
 axum = { version = "0.7", features = ["macros"] }
 tokio = { version = "1.36", features = ["full"] }
 tower = "0.4"
-sqlx = { version = "0.7", features = ["sqlite", "macros", "migrate", "runtime-tokio", "chrono"] }
+sqlx = { version = "0.7", features = ["sqlite", "macros", "migrate", "runtime-tokio", "chrono", "uuid"] }
 serde = "1.0"
 serde_with = "3.7"
 dotenv = "0.15"
+argon2 = { version = "0.5", features = ["std"] }

--- a/migrations/0001_create_tasks_table.sql
+++ b/migrations/0001_create_tasks_table.sql
@@ -1,8 +1,0 @@
-CREATE TABLE Tasks(
-  id INTEGER PRIMARY KEY NOT NULL,
-  timespan_start DATETIME NOT NULL,
-  timespan_end   DATETIME NOT NULL,
-  duration       INTEGER NOT NULL,
-  effect         REAL    NOT NULL
-);
-

--- a/migrations/0001_initial_schema.sql
+++ b/migrations/0001_initial_schema.sql
@@ -1,0 +1,22 @@
+CREATE TABLE Accounts(
+  id     INTEGER PRIMARY KEY NOT NULL,
+  username      VARCHAR(255) NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  UNIQUE(username)
+);
+
+CREATE TABLE AuthTokens(
+  id VARCHAR(64) PRIMARY KEY NOT NULL,
+  account_id         INTEGER NOT NULL
+    REFERENCES Accounts(id) ON DELETE CASCADE
+);
+
+CREATE TABLE Tasks(
+  id  INTEGER PRIMARY KEY NOT NULL,
+  timespan_start DATETIME NOT NULL,
+  timespan_end   DATETIME NOT NULL,
+  duration       INTEGER  NOT NULL,
+  effect         REAL     NOT NULL,
+  account_id     INTEGER  NOT NULL
+    REFERENCES Accounts(id) ON DELETE CASCADE
+);

--- a/src/extractors/auth.rs
+++ b/src/extractors/auth.rs
@@ -1,0 +1,92 @@
+use axum::{
+    async_trait,
+    extract::FromRequestParts,
+    http::{request::Parts, HeaderMap, StatusCode},
+};
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+#[derive(Deserialize, Serialize, sqlx::Type)]
+#[sqlx(transparent)]
+pub struct AuthToken(Uuid);
+
+impl AuthToken {
+    fn new() -> Self {
+        AuthToken(Uuid::new_v4())
+    }
+
+    fn try_parse(input: &str) -> Result<AuthToken, uuid::Error> {
+        let uuid = Uuid::try_parse(input)?;
+        Ok(AuthToken(uuid))
+    }
+}
+
+// Account id
+pub struct Authentication(pub i64);
+
+#[async_trait]
+impl FromRequestParts<SqlitePool> for Authentication {
+    type Rejection = (StatusCode, String);
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        pool: &SqlitePool,
+    ) -> Result<Self, Self::Rejection> {
+        match get_auth_token(&parts.headers) {
+            Some(token) => {
+                if let Some(account_id) = get_account_id_from_token(token, pool).await {
+                    Ok(Authentication(account_id))
+                } else {
+                    Err((
+                        StatusCode::UNAUTHORIZED,
+                        "Auth token is not in the database".to_string(),
+                    ))
+                }
+            }
+            _ => Err((
+                StatusCode::UNAUTHORIZED,
+                "Auth token invalid or missing".to_string(),
+            )),
+        }
+    }
+}
+
+fn get_auth_token(headers: &HeaderMap) -> Option<AuthToken> {
+    let string = headers.get("X-Auth-Token")?.to_str().ok()?;
+    AuthToken::try_parse(string).ok()
+}
+
+async fn get_account_id_from_token(token: AuthToken, pool: &SqlitePool) -> Option<i64> {
+    sqlx::query_scalar!(
+        r#"
+        SELECT account_id
+        FROM AuthTokens
+        WHERE id = ?
+        "#,
+        token
+    )
+    .fetch_optional(pool)
+    .await
+    .ok()?
+}
+
+pub async fn create_auth_token(
+    account_id: i64,
+    pool: &SqlitePool,
+) -> Result<AuthToken, sqlx::Error> {
+    let auth_token = AuthToken::new();
+
+    sqlx::query!(
+        r#"
+        INSERT INTO AuthTokens (id, account_id)
+        VALUES (?, ?)
+        "#,
+        auth_token,
+        account_id
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(auth_token)
+}

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/src/handlers/accounts.rs
+++ b/src/handlers/accounts.rs
@@ -1,0 +1,82 @@
+use argon2::{
+    password_hash::{rand_core::OsRng, SaltString},
+    Argon2, PasswordHash, PasswordHasher, PasswordVerifier,
+};
+use axum::{debug_handler, extract::State, http::StatusCode, Json};
+use sqlx::SqlitePool;
+
+use crate::{
+    extractors::auth::create_auth_token,
+    handlers::util::internal_error,
+    protocol::accounts::{RegisterOrLoginRequest, RegisterOrLoginResponse},
+};
+
+#[debug_handler]
+pub async fn register_account(
+    State(pool): State<SqlitePool>,
+    Json(register_request): Json<RegisterOrLoginRequest>,
+) -> Result<Json<RegisterOrLoginResponse>, (StatusCode, String)> {
+    let password = register_request.password;
+    let password_bytes = password.as_bytes();
+    let salt = SaltString::generate(&mut OsRng);
+
+    let argon2 = Argon2::default();
+
+    let password_hash = argon2
+        .hash_password(password_bytes, &salt)
+        .map_err(internal_error)?
+        .to_string();
+
+    let account_id = sqlx::query_scalar!(
+        r#"
+        INSERT INTO Accounts (username, password_hash)
+        VALUES (?, ?)
+        RETURNING id
+        "#,
+        register_request.username,
+        password_hash
+    )
+    .fetch_one(&pool)
+    .await
+    .map_err(internal_error)?;
+
+    let auth_token = create_auth_token(account_id, &pool)
+        .await
+        .map_err(internal_error)?;
+
+    Ok(Json(RegisterOrLoginResponse { auth_token }))
+}
+
+#[debug_handler]
+pub async fn login_to_account(
+    State(pool): State<SqlitePool>,
+    Json(login_request): Json<RegisterOrLoginRequest>,
+) -> Result<Json<RegisterOrLoginResponse>, (StatusCode, String)> {
+    let account = sqlx::query!(
+        r#"
+        SELECT id, password_hash
+        FROM Accounts
+        WHERE username = ?
+        "#,
+        login_request.username
+    )
+    .fetch_optional(&pool)
+    .await
+    .map_err(internal_error)?;
+
+    let account = account.ok_or((
+        StatusCode::NOT_FOUND,
+        "No account with username exists".to_string(),
+    ))?;
+
+    let password_hash = PasswordHash::new(&account.password_hash).map_err(internal_error)?;
+
+    Argon2::default()
+        .verify_password(login_request.password.as_bytes(), &password_hash)
+        .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid password".to_string()))?;
+
+    let auth_token = create_auth_token(account.id, &pool)
+        .await
+        .map_err(internal_error)?;
+    Ok(Json(RegisterOrLoginResponse { auth_token }))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,3 @@
+pub mod accounts;
+pub mod tasks;
+pub mod util;

--- a/src/handlers/tasks.rs
+++ b/src/handlers/tasks.rs
@@ -1,0 +1,65 @@
+use axum::{debug_handler, extract::State, http::StatusCode, Json};
+use sqlx::SqlitePool;
+
+use crate::{
+    data_model::{task::Task, time::Timespan},
+    extractors::auth::Authentication,
+    handlers::util::internal_error,
+};
+
+#[debug_handler]
+pub async fn get_tasks(
+    State(pool): State<SqlitePool>,
+    Authentication(account_id): Authentication,
+) -> Result<Json<Vec<Task>>, (StatusCode, String)> {
+    let tasks = sqlx::query!(
+        r#"
+        SELECT id, timespan_start, timespan_end, duration, effect
+        FROM Tasks
+        WHERE account_id = ?
+        "#,
+        account_id
+    )
+    .fetch_all(&pool)
+    .await
+    .map_err(internal_error)?;
+
+    let my_tasks = tasks
+        .iter()
+        .map(|t| Task {
+            id: t.id,
+            timespan: Timespan::new_from_naive(t.timespan_start, t.timespan_end),
+            duration: t.duration.into(),
+            effect: t.effect,
+        })
+        .collect();
+
+    Ok(Json(my_tasks))
+}
+
+#[debug_handler]
+pub async fn create_task(
+    State(pool): State<SqlitePool>,
+    Authentication(account_id): Authentication,
+    Json(mut task): Json<Task>,
+) -> Result<Json<Task>, (StatusCode, String)> {
+    let id = sqlx::query_scalar!(
+        r#"
+        INSERT INTO Tasks (timespan_start, timespan_end, duration, effect, account_id)
+        VALUES (?, ?, ?, ?, ?)
+        RETURNING id
+        "#,
+        task.timespan.start,
+        task.timespan.end,
+        task.duration,
+        task.effect,
+        account_id
+    )
+    .fetch_one(&pool)
+    .await
+    .map_err(internal_error)?;
+
+    task.id = id;
+
+    Ok(Json(task))
+}

--- a/src/handlers/util.rs
+++ b/src/handlers/util.rs
@@ -1,0 +1,8 @@
+use axum::http::StatusCode;
+
+pub fn internal_error<E>(err: E) -> (StatusCode, String)
+where
+    E: std::error::Error,
+{
+    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,20 @@
-use axum::{
-    debug_handler,
-    extract::State,
-    http::StatusCode,
-    routing::{get, post},
-    Json, Router,
-};
-use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
+mod data_model;
+mod extractors;
+mod handlers;
+mod protocol;
+
 use std::error::Error;
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+use dotenv::dotenv;
+use sqlx::sqlite::SqlitePoolOptions;
 use tokio::net::TcpListener;
 
-use dotenv::dotenv;
-
-mod data_model;
-
-use data_model::task::Task;
-use data_model::time::Timespan;
+use handlers::accounts::*;
+use handlers::tasks::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -31,72 +31,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let app = Router::new()
         .route("/", get(get_tasks))
         .route("/create", post(create_task))
+        .route("/accounts/register", post(register_account))
+        .route("/accounts/login", post(login_to_account))
         .with_state(pool);
 
     let listener = TcpListener::bind("127.0.0.1:3000").await?;
 
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await?;
 
     Ok(())
-}
-
-#[debug_handler]
-async fn get_tasks(
-    State(pool): State<SqlitePool>,
-) -> Result<Json<Vec<Task>>, (StatusCode, String)> {
-    let tasks = sqlx::query!(
-        r#"
-        SELECT id, timespan_start, timespan_end, duration, effect
-    FROM Tasks
-    "#
-    )
-    .fetch_all(&pool)
-    .await
-    .map_err(internal_error)?;
-
-    let my_tasks = tasks
-        .iter()
-        .map(|t| Task {
-            id: t.id,
-            timespan: Timespan::new_from_naive(t.timespan_start, t.timespan_end),
-            duration: t.duration.into(),
-            effect: t.effect,
-        })
-        .collect();
-
-    Ok(Json(my_tasks))
-}
-
-#[debug_handler]
-async fn create_task(
-    State(pool): State<SqlitePool>,
-    Json(mut task): Json<Task>,
-) -> Result<Json<Task>, (StatusCode, String)> {
-    let id = sqlx::query_scalar!(
-        r#"
-    INSERT INTO Tasks (timespan_start, timespan_end, duration, effect)
-    VALUES (?, ?, ?, ?)
-    RETURNING id
-    "#,
-        task.timespan.start,
-        task.timespan.end,
-        task.duration,
-        task.effect
-    )
-    .fetch_one(&pool)
-    .await
-    .map_err(internal_error)?;
-
-    task.id = id;
-
-    Ok(Json(task))
-}
-
-/// Utility function for mapping any error into a `500 Internal Server Error`
-/// response.
-fn internal_error<E>(err: E) -> (StatusCode, String)
-where
-    E: std::error::Error,
-{
-    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
 }

--- a/src/protocol/accounts.rs
+++ b/src/protocol/accounts.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+use crate::extractors::auth::AuthToken;
+
+#[derive(Deserialize, Serialize)]
+pub struct RegisterOrLoginRequest {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct RegisterOrLoginResponse {
+    pub auth_token: AuthToken,
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,0 +1,1 @@
+pub mod accounts;


### PR DESCRIPTION
Add endpoints `/accounts/register` & `/accounts/login`

When you register or login successfully you receive an auth token. This needs to be sent in the `X-Auth-Token` header in authenticated endpoints.
To make an endpoint authenticated add the `Authentication` extractor to the endpoint.
This will make the id of the account available to the endpoint. If the authentication token is invalid the request terminates with an error and the endpoint handler is never executed.